### PR TITLE
Add LinkedIn post pipeline definition

### DIFF
--- a/LinkedInChain
+++ b/LinkedInChain
@@ -3,14 +3,46 @@
   "description": "Maakt een inputveld, schrijft een LinkedIn-post, maakt een Sora-afbeeldingprompt en presenteert tekst + beeld.",
   "version": "1.0",
   "inputs": {
-    "onderwerp": { "type": "string", "label": "Onderwerp / invalshoek", "required": true },
-    "informatie": { "type": "text", "label": "Feiten, bullets, cijfers, quotes", "required": true },
-    "doelgroep": { "type": "string", "label": "Primair publiek (bijv. dealers, herstellers, klanten)", "required": true },
-    "tone": { "type": "string", "label": "Schrijfstijl (bijv. concreet, inspirerend, expert)", "default": "concreet" },
-    "cta": { "type": "string", "label": "Call-to-action", "default": "Deel je ervaring in de reacties." },
-    "hashtags": { "type": "string", "label": "Hashtags, komma-gescheiden", "default": "automotive,schadeafhandeling,innovatie" },
-    "beeldstijl": { "type": "string", "label": "Beeldstijl voor Sora (bijv. clean, high-tech, editorial)", "default": "clean" },
-    "merkassets_opt": { "type": "text", "label": "Optioneel: merk- of kleurenrichtlijnen", "required": false }
+    "onderwerp": {
+      "type": "string",
+      "label": "Onderwerp / invalshoek",
+      "required": true
+    },
+    "informatie": {
+      "type": "text",
+      "label": "Feiten, bullets, cijfers, quotes",
+      "required": true
+    },
+    "doelgroep": {
+      "type": "string",
+      "label": "Primair publiek (bijv. dealers, herstellers, klanten)",
+      "required": true
+    },
+    "tone": {
+      "type": "string",
+      "label": "Schrijfstijl (bijv. concreet, inspirerend, expert)",
+      "default": "concreet"
+    },
+    "cta": {
+      "type": "string",
+      "label": "Call-to-action",
+      "default": "Deel je ervaring in de reacties."
+    },
+    "hashtags": {
+      "type": "string",
+      "label": "Hashtags, komma-gescheiden",
+      "default": "automotive,schadeafhandeling,innovatie"
+    },
+    "beeldstijl": {
+      "type": "string",
+      "label": "Beeldstijl voor Sora (bijv. clean, high-tech, editorial)",
+      "default": "clean"
+    },
+    "merkassets_opt": {
+      "type": "text",
+      "label": "Optioneel: merk- of kleurenrichtlijnen",
+      "required": false
+    }
   },
   "actions": [
     {
@@ -23,19 +55,25 @@
       "type": "chatgpt.generate",
       "model": "gpt-5",
       "input_ref": "post_prompt",
-      "outputs": { "text": "post_text" }
+      "outputs": {
+        "text": "post_text"
+      }
     },
     {
       "id": "sora_prompt",
       "type": "compose",
       "template": "Create one still image for a LinkedIn post.\nPurpose: illustrate the following post text:\n\"\"\"\n{{post_text}}\n\"\"\"\nImage requirements:\n- Style: {{beeldstijl}}. Editorial, minimal, high legibility in feed. 1200x1200.\n- Subject matter must visually encode the core idea from the post. Prefer metaphor over literal car photos unless facts demand it.\n- Composition: strong focal point, negative space top-right for overlaid copy if needed.\n- Lighting: soft studio or natural rim light. No harsh contrast.\n- Colors: align with brand if provided.\n- Text in image: none.\n- No logos unless explicitly provided in brand assets.\nIf brand guidelines provided, apply:\n{{merkassets_opt}}",
-      "vars": { "post_text": "{{gen_post.post_text}}" }
+      "vars": {
+        "post_text": "{{gen_post.post_text}}"
+      }
     },
     {
       "id": "gen_image",
       "type": "sora.generate_image",
       "prompt_ref": "sora_prompt",
-      "outputs": { "url": "image_url" }
+      "outputs": {
+        "url": "image_url"
+      }
     },
     {
       "id": "present",

--- a/linkedin_post_pipeline.json
+++ b/linkedin_post_pipeline.json
@@ -3,14 +3,46 @@
   "description": "Maakt een inputveld, schrijft een LinkedIn-post, maakt een Sora-afbeeldingprompt en presenteert tekst + beeld.",
   "version": "1.0",
   "inputs": {
-    "onderwerp": { "type": "string", "label": "Onderwerp / invalshoek", "required": true },
-    "informatie": { "type": "text", "label": "Feiten, bullets, cijfers, quotes", "required": true },
-    "doelgroep": { "type": "string", "label": "Primair publiek (bijv. dealers, herstellers, klanten)", "required": true },
-    "tone": { "type": "string", "label": "Schrijfstijl (bijv. concreet, inspirerend, expert)", "default": "concreet" },
-    "cta": { "type": "string", "label": "Call-to-action", "default": "Deel je ervaring in de reacties." },
-    "hashtags": { "type": "string", "label": "Hashtags, komma-gescheiden", "default": "automotive,schadeafhandeling,innovatie" },
-    "beeldstijl": { "type": "string", "label": "Beeldstijl voor Sora (bijv. clean, high-tech, editorial)", "default": "clean" },
-    "merkassets_opt": { "type": "text", "label": "Optioneel: merk- of kleurenrichtlijnen", "required": false }
+    "onderwerp": {
+      "type": "string",
+      "label": "Onderwerp / invalshoek",
+      "required": true
+    },
+    "informatie": {
+      "type": "text",
+      "label": "Feiten, bullets, cijfers, quotes",
+      "required": true
+    },
+    "doelgroep": {
+      "type": "string",
+      "label": "Primair publiek (bijv. dealers, herstellers, klanten)",
+      "required": true
+    },
+    "tone": {
+      "type": "string",
+      "label": "Schrijfstijl (bijv. concreet, inspirerend, expert)",
+      "default": "concreet"
+    },
+    "cta": {
+      "type": "string",
+      "label": "Call-to-action",
+      "default": "Deel je ervaring in de reacties."
+    },
+    "hashtags": {
+      "type": "string",
+      "label": "Hashtags, komma-gescheiden",
+      "default": "automotive,schadeafhandeling,innovatie"
+    },
+    "beeldstijl": {
+      "type": "string",
+      "label": "Beeldstijl voor Sora (bijv. clean, high-tech, editorial)",
+      "default": "clean"
+    },
+    "merkassets_opt": {
+      "type": "text",
+      "label": "Optioneel: merk- of kleurenrichtlijnen",
+      "required": false
+    }
   },
   "actions": [
     {
@@ -23,19 +55,25 @@
       "type": "chatgpt.generate",
       "model": "gpt-5",
       "input_ref": "post_prompt",
-      "outputs": { "text": "post_text" }
+      "outputs": {
+        "text": "post_text"
+      }
     },
     {
       "id": "sora_prompt",
       "type": "compose",
       "template": "Create one still image for a LinkedIn post.\nPurpose: illustrate the following post text:\n\"\"\"\n{{post_text}}\n\"\"\"\nImage requirements:\n- Style: {{beeldstijl}}. Editorial, minimal, high legibility in feed. 1200x1200.\n- Subject matter must visually encode the core idea from the post. Prefer metaphor over literal car photos unless facts demand it.\n- Composition: strong focal point, negative space top-right for overlaid copy if needed.\n- Lighting: soft studio or natural rim light. No harsh contrast.\n- Colors: align with brand if provided.\n- Text in image: none.\n- No logos unless explicitly provided in brand assets.\nIf brand guidelines provided, apply:\n{{merkassets_opt}}",
-      "vars": { "post_text": "{{gen_post.post_text}}" }
+      "vars": {
+        "post_text": "{{gen_post.post_text}}"
+      }
     },
     {
       "id": "gen_image",
       "type": "sora.generate_image",
       "prompt_ref": "sora_prompt",
-      "outputs": { "url": "image_url" }
+      "outputs": {
+        "url": "image_url"
+      }
     },
     {
       "id": "present",

--- a/linkedin_post_pipeline.json
+++ b/linkedin_post_pipeline.json
@@ -1,0 +1,50 @@
+{
+  "name": "linkedin_post_pipeline",
+  "description": "Maakt een inputveld, schrijft een LinkedIn-post, maakt een Sora-afbeeldingprompt en presenteert tekst + beeld.",
+  "version": "1.0",
+  "inputs": {
+    "onderwerp": { "type": "string", "label": "Onderwerp / invalshoek", "required": true },
+    "informatie": { "type": "text", "label": "Feiten, bullets, cijfers, quotes", "required": true },
+    "doelgroep": { "type": "string", "label": "Primair publiek (bijv. dealers, herstellers, klanten)", "required": true },
+    "tone": { "type": "string", "label": "Schrijfstijl (bijv. concreet, inspirerend, expert)", "default": "concreet" },
+    "cta": { "type": "string", "label": "Call-to-action", "default": "Deel je ervaring in de reacties." },
+    "hashtags": { "type": "string", "label": "Hashtags, komma-gescheiden", "default": "automotive,schadeafhandeling,innovatie" },
+    "beeldstijl": { "type": "string", "label": "Beeldstijl voor Sora (bijv. clean, high-tech, editorial)", "default": "clean" },
+    "merkassets_opt": { "type": "text", "label": "Optioneel: merk- of kleurenrichtlijnen", "required": false }
+  },
+  "actions": [
+    {
+      "id": "post_prompt",
+      "type": "compose",
+      "template": "SYSTEM:\nJe bent een strikte LinkedIn-copywriter. Korte alinea's. Geen uitroeptekens. Nederlands.\n\nUSER:\nSchrijf een LinkedIn-post over: {{onderwerp}}\nDoelgroep: {{doelgroep}}\nStijl: {{tone}}\nFeiten/bullets:\n{{informatie}}\nVereisten:\n- Sterke hook in zin 1.\n- 3–6 korte alinea's. Max 120 woorden totaal.\n- 1 duidelijke CTA: {{cta}}\n- Voeg op het eind 3–6 relevante hashtags uit: {{hashtags}}.\n- Geen emoticons. Geen opsommingstekens. Geen overdrijving.\n- Vermijd jargon. Schrijf actief. Bewijs waar nodig met één concreet detail."
+    },
+    {
+      "id": "gen_post",
+      "type": "chatgpt.generate",
+      "model": "gpt-5",
+      "input_ref": "post_prompt",
+      "outputs": { "text": "post_text" }
+    },
+    {
+      "id": "sora_prompt",
+      "type": "compose",
+      "template": "Create one still image for a LinkedIn post.\nPurpose: illustrate the following post text:\n\"\"\"\n{{post_text}}\n\"\"\"\nImage requirements:\n- Style: {{beeldstijl}}. Editorial, minimal, high legibility in feed. 1200x1200.\n- Subject matter must visually encode the core idea from the post. Prefer metaphor over literal car photos unless facts demand it.\n- Composition: strong focal point, negative space top-right for overlaid copy if needed.\n- Lighting: soft studio or natural rim light. No harsh contrast.\n- Colors: align with brand if provided.\n- Text in image: none.\n- No logos unless explicitly provided in brand assets.\nIf brand guidelines provided, apply:\n{{merkassets_opt}}",
+      "vars": { "post_text": "{{gen_post.post_text}}" }
+    },
+    {
+      "id": "gen_image",
+      "type": "sora.generate_image",
+      "prompt_ref": "sora_prompt",
+      "outputs": { "url": "image_url" }
+    },
+    {
+      "id": "present",
+      "type": "present.card",
+      "title": "{{onderwerp}}",
+      "fields": {
+        "LinkedIn-tekst": "{{gen_post.post_text}}",
+        "Afbeelding": "{{gen_image.image_url}}"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a pipeline JSON definition for generating LinkedIn posts with supporting image prompts
- include inputs for topic, facts, audience, tone, CTA, hashtags, visual style, and optional brand assets
- wire compose, ChatGPT generation, Sora image creation, and card presentation actions into the pipeline

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4db545af0832390e6e27c6df68b2b